### PR TITLE
Added "timeout" configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ end
 * `password` - OpenNebula password
 * `template_id` - OpenNebula template id
 * `title` - OpenNebula instance name
-* `timeout` - The number of seconds to wait for the instance state to change in the OpenNebula
+* `timeout` - The number of seconds to wait for the instance state to change in the OpenNebula. Defaults to 120 seconds.
 * `memory` - An instance memory in MB
 * `cpu` - An instance cpus
 * `vcpu` - An instance virtual cpus

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ end
 * `password` - OpenNebula password
 * `template_id` - OpenNebula template id
 * `title` - OpenNebula instance name
+* `timeout` - The number of seconds to wait for the instance state to change in the OpenNebula
 * `memory` - An instance memory in MB
 * `cpu` - An instance cpus
 * `vcpu` - An instance virtual cpus

--- a/lib/opennebula-provider/config.rb
+++ b/lib/opennebula-provider/config.rb
@@ -11,6 +11,7 @@ module VagrantPlugins
       attr_accessor :os_tpl
       attr_accessor :resource_tpl
       attr_accessor :title
+      attr_accessor :timeout
       attr_accessor :memory
       attr_accessor :cpu
       attr_accessor :vcpu
@@ -25,6 +26,7 @@ module VagrantPlugins
         @os_tpl = UNSET_VALUE
         @resource_tpl = UNSET_VALUE
         @title = UNSET_VALUE
+        @timeout = UNSET_VALUE
         @memory = UNSET_VALUE
         @cpu = UNSET_VALUE
         @vcpu = UNSET_VALUE
@@ -46,6 +48,7 @@ module VagrantPlugins
         end
         @resource_tpl = 'small' if @resource_tpl == UNSET_VALUE
         @title = nil if @title == UNSET_VALUE
+        @timeout = 120 if @timeout == UNSET_VALUE
         @memory = nil if @memory == UNSET_VALUE
         @vcpu = nil if @vcpu == UNSET_VALUE
         @cpu = nil if @cpu == UNSET_VALUE
@@ -61,6 +64,7 @@ module VagrantPlugins
         errors << I18n.t('opennebula_provider.config.password') unless @password
         errors << I18n.t('opennebula_provider.config.template') unless @template
         errors << I18n.t('opennebula_provider.config.title') unless @title
+        errors << I18n.t('opennebula_provider.config.timeout') unless @timeout.is_a? Integer
 
         { 'OpenNebula provider' => errors }
       end

--- a/lib/opennebula-provider/driver.rb
+++ b/lib/opennebula-provider/driver.rb
@@ -54,7 +54,9 @@ module VagrantPlugins
       end
 
       def wait_for_state(env, state)
-        retryable(tries: 60, sleep: 2) do
+        timeout = env[:machine].provider_config.timeout
+        max_tries = timeout / 2
+        retryable(tries: max_tries, sleep: 2) do
           next if env[:interrupted]
           env[:machine_state] = @fog_driver.machine_state(env[:machine].id)
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -100,6 +100,8 @@ en:
         An template must defined via "template_id" or "template_name"
       title: |-
         VM title is not set
+      timeout: |-
+        Timeout is not an integer
 
     compute:
       template_missing: |-


### PR DESCRIPTION
Sometimes a VM initialization could take more than 120 seconds and `vagrant up` fails with the following error:
> Compute error! Can not wait when instance will be in 'active' status, last status is 'pending'

So it would be nice to be able to configure the timeout through the Vagrantfile if we work with a slow/overloaded cluster.