### PR TITLE
Fog: wait for ssh to determine VM readiness

### DIFF
--- a/lib/opennebula-provider/driver.rb
+++ b/lib/opennebula-provider/driver.rb
@@ -64,6 +64,11 @@ module VagrantPlugins
             fail Errors::ComputeError,
               error: "Can not wait when instance will be in '#{state}' status, " \
                      "last status is '#{env[:machine_state]}'"
+          else env[:machine_state] == :active
+              is_ssh_ready = env[:machine].communicate.ready?
+              if !is_ssh_ready
+                fail Errors::ComputeError, error: "SSH not ready yet"
+              end
           end
         end
       end

--- a/lib/opennebula-provider/version.rb
+++ b/lib/opennebula-provider/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module OpenNebulaProvider
-    VERSION = '1.0.0'
+    VERSION = '1.0.1'
   end
 end


### PR DESCRIPTION
Hi @eucher 
I'm so grateful to you for you job. This branch of your plugin resolve so much problems for me. 
There some kind of bug:
When I try to provision right after VM deploying e.g
`vagrant destroy --force && vagrant up --provider=opennebula && vagrant provision`
ssh could be not ready (not started) for this moment and I got an error.
This little patch adds to `up` command `communicate.ready` check.

It wold be great if you release `fog` version of this plugin to get rid of installation from `gem` files. Just because vagrant 1.8.4 have a bug which does not allow to install the plugin from file.

Thanks!