### PR TITLE
Parallel VM up

### DIFF
--- a/lib/opennebula-provider/plugin.rb
+++ b/lib/opennebula-provider/plugin.rb
@@ -13,7 +13,7 @@ module VagrantPlugins
         Config
       end
 
-      provider(:opennebula) do
+      provider(:opennebula, parallel: true) do
         require_relative 'provider'
         Provider
       end


### PR DESCRIPTION
It will drastically speedup VMs depolying. For two machines in my case it's about 30% time less.
`--no-parallel` would disable it.