### PR TITLE
Fixed lack of RsyncError

### DIFF
--- a/lib/opennebula-provider/errors.rb
+++ b/lib/opennebula-provider/errors.rb
@@ -28,6 +28,10 @@ module VagrantPlugins
       class QuotaError < OpenNebulaProviderError
         error_key(:quota)
       end
+
+      class RsyncError < OpenNebulaProviderError
+        error_key(:rsync)
+      end
     end
   end
 end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -120,3 +120,5 @@ en:
         Resource error! %{error}
       quota: |-
         Quota error! %{error}
+      rsync: |-
+        Rsync error! %{stderr}


### PR DESCRIPTION
It was `uninitialized constant VagrantPlugins::OpenNebulaProvider::Err
ors::RsyncError (NameError)` when rsync fails.