### PR TITLE
Now selecting template via `tempate_name` works

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,13 @@ end
 * `username` - OpenNebula username
 * `password` - OpenNebula password
 * `template_id` - OpenNebula template id
+* `template_name` - OpenNebula template name
 * `title` - OpenNebula instance name
 * `memory` - An instance memory in MB
 * `cpu` - An instance cpus
 * `vcpu` - An instance virtual cpus
+
+You can use `template_name` parameters instead `template_id` to define template by name and if there are multiple templates with the same name will be used the most recent. 
 
 You can use ONE_USER, ONE_PASSWORD, ONE_XMLRPC (or ONE_ENDPOINT) environment variables
 instead of defining it in Vagrantfile.

--- a/lib/opennebula-provider/helpers/fog.rb
+++ b/lib/opennebula-provider/helpers/fog.rb
@@ -41,7 +41,7 @@ module VagrantPlugins
           if @provider_config.template_id
             newvm.flavor = @fog_client.flavors.get @provider_config.template_id
           elsif @provider_config.template_name
-            newvm.flavor = @fog_client.flavors.get_by_filter({name: @provider_config.template_name}).first
+            newvm.flavor = @fog_client.flavors.get_by_filter({name: @provider_config.template_name}).last
           end
           if newvm.flavor.nil?
             fail Errors::ComputeError, error: I18n.t('opennebula_provider.compute.template_missing', template: @provider_config.template)

--- a/lib/opennebula-provider/helpers/fog.rb
+++ b/lib/opennebula-provider/helpers/fog.rb
@@ -41,7 +41,7 @@ module VagrantPlugins
           if @provider_config.template_id
             newvm.flavor = @fog_client.flavors.get @provider_config.template_id
           elsif @provider_config.template_name
-            newvm.flavor = @fog_client.flavors.get_by_filter({name: @provider_config.template_name})
+            newvm.flavor = @fog_client.flavors.get_by_filter({name: @provider_config.template_name}).first
           end
           if newvm.flavor.nil?
             fail Errors::ComputeError, error: I18n.t('opennebula_provider.compute.template_missing', template: @provider_config.template)


### PR DESCRIPTION
Tehere was error when template_name defined:
undefined method `context' for #<Fog::Compute::OpenNebula::Flavors:0x00000002da6a40>
/root/.vagrant.d/gems/gems/opennebula-provider-1.1.0/lib/opennebula-provider/helpers/fog.rb:53:in
`compute'