### PR TITLE
Change VM name in config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Vagrant.configure("2") do |config|
     one.username = 'YOUR NAME'
     one.password = 'YOUR PASSWORD'
     one.template_id = 123
-    one.title = 'my vm'
+    one.title = 'my-vm'
   end
 end
 ```


### PR DESCRIPTION
String handling is broken somewhere. As is, you can create 'my-vm', but not 'my vm'.
If we change like this, the example will work (underlying issue not a big thing once you know)
