### PR TITLE
Add ability to specify vm disk size

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ end
 * `memory` - An instance memory in MB
 * `cpu` - An instance cpus
 * `vcpu` - An instance virtual cpus
+* `disk_size` - Disk size, in MB, for templates with ONLY one disk
 
 You can use `template_name` parameters instead `template_id` to define template by name and if there are multiple templates with the same name will be used the most recent. 
 

--- a/lib/opennebula-provider/config.rb
+++ b/lib/opennebula-provider/config.rb
@@ -14,6 +14,7 @@ module VagrantPlugins
       attr_accessor :memory
       attr_accessor :cpu
       attr_accessor :vcpu
+      attr_accessor :disk_size
 
       def initialize
         @endpoint = ENV['ONE_XMLRPC'] || ENV['ONE_ENDPOINT'] || UNSET_VALUE
@@ -28,6 +29,7 @@ module VagrantPlugins
         @memory = UNSET_VALUE
         @cpu = UNSET_VALUE
         @vcpu = UNSET_VALUE
+        @disk_size = UNSET_VALUE
       end
 
       def finalize!
@@ -52,6 +54,7 @@ module VagrantPlugins
         if @cpu && ! @vcpu
           @vcpu = @cpu
         end
+        @disk_size = nil if @disk_size == UNSET_VALUE
       end
 
       def validate(machine)

--- a/lib/opennebula-provider/helpers/fog.rb
+++ b/lib/opennebula-provider/helpers/fog.rb
@@ -58,6 +58,18 @@ module VagrantPlugins
           newvm.flavor.memory = @provider_config.memory unless @provider_config.memory.nil?
           newvm.flavor.cpu = @provider_config.cpu unless @provider_config.cpu.nil?
           newvm.flavor.vcpu = @provider_config.vcpu unless @provider_config.vcpu.nil?
+
+          if newvm.flavor.disk.instance_of? Array
+            fail Errors::AllocateError, error: I18n.t(
+                'opennebula_provider.errors.allocate',
+                error: 'Template has more than one disk attached and `disk_size` ' +
+                       'feature is supported only for templates with only one')
+          end
+
+          if @provider_config.disk_size != nil
+            newvm.flavor.disk["size"] = @provider_config.disk_size
+          end
+          @logger.warn "Deploying VM with options #{newvm.flavor.inspect}"
           vm = newvm.save
           vm.id
         rescue RuntimeError => e

--- a/lib/opennebula-provider/version.rb
+++ b/lib/opennebula-provider/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module OpenNebulaProvider
-    VERSION = '1.1.2'
+    VERSION = '1.1.3'
   end
 end


### PR DESCRIPTION
Add `disk_size` vm option which works only for templates with only one disk attached.