### PR TITLE
Fix #27: Add user_variables parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ end
 * `cpu` - An instance cpus
 * `vcpu` - An instance virtual cpus
 * `disk_size` - Disk size, in MB, for templates with ONLY one disk
+* `user_variables` - An instance specified variables (like 'CPU_MODEL = [ MODEL = host-passthrough ]')
 
 You can use `template_name` parameters instead `template_id` to define template by name and if there are multiple templates with the same name will be used the most recent. 
 

--- a/lib/opennebula-provider/config.rb
+++ b/lib/opennebula-provider/config.rb
@@ -15,6 +15,7 @@ module VagrantPlugins
       attr_accessor :cpu
       attr_accessor :vcpu
       attr_accessor :disk_size
+      attr_accessor :user_variables
 
       def initialize
         @endpoint = ENV['ONE_XMLRPC'] || ENV['ONE_ENDPOINT'] || UNSET_VALUE
@@ -30,6 +31,7 @@ module VagrantPlugins
         @cpu = UNSET_VALUE
         @vcpu = UNSET_VALUE
         @disk_size = UNSET_VALUE
+        @user_variables = UNSET_VALUE
       end
 
       def finalize!
@@ -55,6 +57,7 @@ module VagrantPlugins
           @vcpu = @cpu
         end
         @disk_size = nil if @disk_size == UNSET_VALUE
+        @user_variables = nil if @user_variables == UNSET_VALUE
       end
 
       def validate(machine)

--- a/lib/opennebula-provider/helpers/fog.rb
+++ b/lib/opennebula-provider/helpers/fog.rb
@@ -69,6 +69,7 @@ module VagrantPlugins
           if @provider_config.disk_size != nil
             newvm.flavor.disk["SIZE"] = @provider_config.disk_size
           end
+          newvm.flavor.user_variables = @provider_config.user_variables unless @provider_config.user_variables.nil?
           @logger.warn "Deploying VM with options #{newvm.flavor.inspect}"
           vm = newvm.save
           vm.id


### PR DESCRIPTION
Add `user_variables` parameter, that allow to specify VM options, like `CPU_MODEL = [ MODEL = host-passthrough ]`